### PR TITLE
Enable dfs.webhdfs.rest-csrf.enabled

### DIFF
--- a/kubernetes/base/common/config/hadoop/hdfs-site.xml
+++ b/kubernetes/base/common/config/hadoop/hdfs-site.xml
@@ -100,4 +100,9 @@
     <name>dfs.datanode.ipc.address</name>
     <value>0.0.0.0:9867</value>
   </property>
+
+  <property>
+    <name>dfs.webhdfs.rest-csrf.enabled</name>
+    <value>true</value>
+  </property>
 </configuration>


### PR DESCRIPTION
Suppress these WARN logs.

```
pod/hdfs-datanode-0: 2023-02-23 06:12:26,459 WARN web.DatanodeHttpServer: Got null for restCsrfPreventionFilter - will not do any filtering.
pod/hdfs-datanode-1: 2023-02-23 06:12:46,341 WARN web.DatanodeHttpServer: Got null for restCsrfPreventionFilter - will not do any filtering.
pod/hdfs-datanode-2: 2023-02-23 06:12:18,256 WARN web.DatanodeHttpServer: Got null for restCsrfPreventionFilter - will not do any filtering.
```