### PR TITLE
Migrate bases to resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ zookage@client-node-0:~$ beeline
 
 ### Components and versions
 
-Changing [kustomization.yaml](https://github.com/zookage/zookage/blob/main/kubernetes/kustomization.yaml), you can include/exclude any components in `bases` and specify their versions in `images`.
+Changing [kustomization.yaml](https://github.com/zookage/zookage/blob/main/kubernetes/kustomization.yaml), you can include/exclude any components in `resources` and specify their versions in `images`.
 
 You should also check [Compatibility](https://github.com/zookage/zookage#compatibility) and pick up a valid combination.
 

--- a/kubernetes/base/client/kustomization.yaml
+++ b/kubernetes/base/client/kustomization.yaml
@@ -1,4 +1,4 @@
-bases:
+resources:
 - mkdir
 - node
 commonLabels:

--- a/kubernetes/base/common/kustomization.yaml
+++ b/kubernetes/base/common/kustomization.yaml
@@ -1,7 +1,6 @@
-bases:
+resources:
+- namespace.yaml
 - package
 - config
 - env
 - role
-resources:
-- namespace.yaml

--- a/kubernetes/base/common/package/kustomization.yaml
+++ b/kubernetes/base/common/package/kustomization.yaml
@@ -1,4 +1,4 @@
-bases:
+resources:
 - hadoop
 - hbase
 - hive

--- a/kubernetes/base/hbase/kustomization.yaml
+++ b/kubernetes/base/hbase/kustomization.yaml
@@ -1,4 +1,4 @@
-bases:
+resources:
 - mkdir
 - master
 - regionserver

--- a/kubernetes/base/hdfs/kustomization.yaml
+++ b/kubernetes/base/hdfs/kustomization.yaml
@@ -1,4 +1,4 @@
-bases:
+resources:
 - journalnode
 - namenode
 - mkdir

--- a/kubernetes/base/hive/kustomization.yaml
+++ b/kubernetes/base/hive/kustomization.yaml
@@ -1,4 +1,4 @@
-bases:
+resources:
 - mkdir
 - metastore
 - hiveserver2

--- a/kubernetes/base/mapreduce/kustomization.yaml
+++ b/kubernetes/base/mapreduce/kustomization.yaml
@@ -1,4 +1,4 @@
-bases:
+resources:
 - mkdir
 - historyserver
 commonLabels:

--- a/kubernetes/base/ozone/kustomization.yaml
+++ b/kubernetes/base/ozone/kustomization.yaml
@@ -1,4 +1,4 @@
-bases:
+resources:
 - scm
 - om
 - recon

--- a/kubernetes/base/spark/kustomization.yaml
+++ b/kubernetes/base/spark/kustomization.yaml
@@ -1,4 +1,4 @@
-bases:
+resources:
 - mkdir
 - historyserver
 commonLabels:

--- a/kubernetes/base/tez/kustomization.yaml
+++ b/kubernetes/base/tez/kustomization.yaml
@@ -1,4 +1,4 @@
-bases:
+resources:
 - deploy
 - ui
 commonLabels:

--- a/kubernetes/base/trino/kustomization.yaml
+++ b/kubernetes/base/trino/kustomization.yaml
@@ -1,4 +1,4 @@
-bases:
+resources:
 - coordinator
 - worker
 commonLabels:

--- a/kubernetes/base/yarn/kustomization.yaml
+++ b/kubernetes/base/yarn/kustomization.yaml
@@ -1,4 +1,4 @@
-bases:
+resources:
 - mkdir
 - resourcemanager
 - nodemanager

--- a/kubernetes/base/zookeeper/kustomization.yaml
+++ b/kubernetes/base/zookeeper/kustomization.yaml
@@ -1,4 +1,4 @@
-bases:
+resources:
 - server
 commonLabels:
   component: zookeeper

--- a/kubernetes/kustomization.yaml
+++ b/kubernetes/kustomization.yaml
@@ -1,7 +1,7 @@
 namespace: zookage
 commonLabels:
   owner: zookage
-bases:
+resources:
 - base/common
 # - base/zookeeper
 - base/hdfs


### PR DESCRIPTION
Follow this message

```
# Warning: 'bases' is deprecated. Please use 'resources' instead. Run 'kustomize edit fix' to update your Kustomization automatically.
```