### PR TITLE
Disable YARN ACL by default

### DIFF
--- a/kubernetes/base/common/config/hadoop/yarn-site.xml
+++ b/kubernetes/base/common/config/hadoop/yarn-site.xml
@@ -101,10 +101,6 @@
   </property>
 
   <property>
-    <name>yarn.acl.enable</name>
-    <value>true</value>
-  </property>
-  <property>
     <name>yarn.webapp.ui2.enable</name>
     <value>true</value>
   </property>


### PR DESCRIPTION
For convenience. Hadoop 3.3 normalize authentication filters and then "dr.who" is not used for ATS. Then, we would need authentication on Tez UI.