### PR TITLE
Use /var/lib on localhost

### DIFF
--- a/kubernetes/base/common/package/hadoop/job.yaml
+++ b/kubernetes/base/common/package/hadoop/job.yaml
@@ -35,4 +35,4 @@ spec:
       volumes:
       - name: package-home
         hostPath:
-          path: /opt/zookage
+          path: /var/lib/zookage

--- a/kubernetes/base/common/package/hadoop/persistentvolume.yaml
+++ b/kubernetes/base/common/package/hadoop/persistentvolume.yaml
@@ -20,5 +20,5 @@ spec:
   capacity:
     storage: 1Gi
   hostPath:
-    path: /opt/zookage/hadoop
+    path: /var/lib/zookage/hadoop
   storageClassName: zookage-package-hadoop

--- a/kubernetes/base/common/package/hbase/job.yaml
+++ b/kubernetes/base/common/package/hbase/job.yaml
@@ -35,4 +35,4 @@ spec:
       volumes:
       - name: package-home
         hostPath:
-          path: /opt/zookage
+          path: /var/lib/zookage

--- a/kubernetes/base/common/package/hbase/persistentvolume.yaml
+++ b/kubernetes/base/common/package/hbase/persistentvolume.yaml
@@ -20,5 +20,5 @@ spec:
   capacity:
     storage: 1Gi
   hostPath:
-    path: /opt/zookage/hbase-client
+    path: /var/lib/zookage/hbase-client
   storageClassName: zookage-package-hbase-client

--- a/kubernetes/base/common/package/hive/job.yaml
+++ b/kubernetes/base/common/package/hive/job.yaml
@@ -38,4 +38,4 @@ spec:
       volumes:
       - name: package-home
         hostPath:
-          path: /opt/zookage
+          path: /var/lib/zookage

--- a/kubernetes/base/common/package/hive/persistentvolume.yaml
+++ b/kubernetes/base/common/package/hive/persistentvolume.yaml
@@ -20,5 +20,5 @@ spec:
   capacity:
     storage: 512Mi
   hostPath:
-    path: /opt/zookage/hive
+    path: /var/lib/zookage/hive
   storageClassName: zookage-package-hive

--- a/kubernetes/base/common/package/ozone/job.yaml
+++ b/kubernetes/base/common/package/ozone/job.yaml
@@ -35,4 +35,4 @@ spec:
       volumes:
       - name: package-home
         hostPath:
-          path: /opt/zookage
+          path: /var/lib/zookage

--- a/kubernetes/base/common/package/ozone/persistentvolume.yaml
+++ b/kubernetes/base/common/package/ozone/persistentvolume.yaml
@@ -20,5 +20,5 @@ spec:
   capacity:
     storage: 1Gi
   hostPath:
-    path: /opt/zookage/ozone
+    path: /var/lib/zookage/ozone
   storageClassName: zookage-package-ozone

--- a/kubernetes/base/common/package/spark/job.yaml
+++ b/kubernetes/base/common/package/spark/job.yaml
@@ -35,4 +35,4 @@ spec:
       volumes:
       - name: package-home
         hostPath:
-          path: /opt/zookage
+          path: /var/lib/zookage

--- a/kubernetes/base/common/package/spark/persistentvolume.yaml
+++ b/kubernetes/base/common/package/spark/persistentvolume.yaml
@@ -20,5 +20,5 @@ spec:
   capacity:
     storage: 1Gi
   hostPath:
-    path: /opt/zookage/spark
+    path: /var/lib/zookage/spark
   storageClassName: zookage-package-spark

--- a/kubernetes/base/common/package/tez/job.yaml
+++ b/kubernetes/base/common/package/tez/job.yaml
@@ -41,4 +41,4 @@ spec:
       volumes:
       - name: package-home
         hostPath:
-          path: /opt/zookage
+          path: /var/lib/zookage

--- a/kubernetes/base/common/package/tez/persistentvolume.yaml
+++ b/kubernetes/base/common/package/tez/persistentvolume.yaml
@@ -20,5 +20,5 @@ spec:
   capacity:
     storage: 1Gi
   hostPath:
-    path: /opt/zookage/tez
+    path: /var/lib/zookage/tez
   storageClassName: zookage-package-tez

--- a/kubernetes/base/common/package/trino/job.yaml
+++ b/kubernetes/base/common/package/trino/job.yaml
@@ -38,4 +38,4 @@ spec:
       volumes:
       - name: package-home
         hostPath:
-          path: /opt/zookage
+          path: /var/lib/zookage

--- a/kubernetes/base/common/package/trino/persistentvolume.yaml
+++ b/kubernetes/base/common/package/trino/persistentvolume.yaml
@@ -20,5 +20,5 @@ spec:
   capacity:
     storage: 1Gi
   hostPath:
-    path: /opt/zookage/trino
+    path: /var/lib/zookage/trino
   storageClassName: zookage-package-trino

--- a/kubernetes/base/common/package/zookeeper/job.yaml
+++ b/kubernetes/base/common/package/zookeeper/job.yaml
@@ -35,4 +35,4 @@ spec:
       volumes:
       - name: package-home
         hostPath:
-          path: /opt/zookage
+          path: /var/lib/zookage

--- a/kubernetes/base/common/package/zookeeper/persistentvolume.yaml
+++ b/kubernetes/base/common/package/zookeeper/persistentvolume.yaml
@@ -20,5 +20,5 @@ spec:
   capacity:
     storage: 1Gi
   hostPath:
-    path: /opt/zookage/zookeeper
+    path: /var/lib/zookage/zookeeper
   storageClassName: zookage-package-zookeeper


### PR DESCRIPTION
I have observed `No space left on device` since I upgraded Docker Desktop. It looks like the root partition does not have sufficient space now. Instead, this PR lets us use `/var/lib`, which shares the same device as system resources, whose space can be configured via Docker Desktop.
The most promising long-term solution is [Image Volume](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/), but it is not enabled in most environments yet.