### PR TITLE
Harden CI workflow configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,7 @@ jobs:
       run: ./test/lint.sh
   console-test:
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 15
     steps:
     - uses: actions/checkout@v5
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,21 +18,36 @@ on:
   pull_request:
     branches:
     - main
+permissions:
+  contents: read
+concurrency:
+  group: "${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}"
+  cancel-in-progress: true
+defaults:
+  run:
+    shell: bash
 jobs:
   lint:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
     - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
     - name: Lint
-      run: "${GITHUB_WORKSPACE}/test/lint.sh"
+      run: ./test/lint.sh
   console-test:
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
     steps:
     - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
     - uses: actions/setup-java@v4
       with:
         distribution: temurin
         java-version: '25'
         cache: maven
+        cache-dependency-path: console/pom.xml
     - name: Check formatting and test console
       run: "mvn -f console/pom.xml test"


### PR DESCRIPTION
## Summary
- add workflow-level read-only permissions for repository contents
- cancel stale CI runs with workflow concurrency settings
- set a default `bash` shell and add per-job timeouts
- harden `actions/checkout` with `persist-credentials: false`
- scope Maven cache setup to `console/pom.xml`
- simplify the lint step to use `./test/lint.sh`

## Testing
- `./test/lint.sh`