### PR TITLE
Update dependency update skill for CI, Maven, and LTS-aware Quarkus bumps

### DIFF
--- a/.agents/skills/update-dependencies/SKILL.md
+++ b/.agents/skills/update-dependencies/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: update-dependencies
-description: Update pinned dependency versions in this repository. Use when Codex needs to bump Docker base-image digests, lint/test container images, Kubernetes image tags, or version arguments in `docker/sample-build.env`, `docker/*/Dockerfile`, `docker/build-*.sh`, `kubernetes/kustomization.yaml`, `test/kubernetes/*.yaml`, or `test/*.sh`. Prefer the latest upstream version that stays on the current OS or image variant unless the user asks to change tracks.
+description: Update pinned dependency versions in this repository. Use when Codex needs to bump Docker base-image digests, lint/test container images, Kubernetes image tags, GitHub Actions workflow pins, or Maven dependency and tooling versions in `docker/sample-build.env`, `docker/*/Dockerfile`, `docker/build-*.sh`, `kubernetes/kustomization.yaml`, `test/kubernetes/*.yaml`, `test/*.sh`, `.github/workflows/ci.yaml`, or `console/pom.xml`. Prefer the latest upstream LTS release when the dependency publishes one; otherwise prefer the latest upstream release that stays on the current OS or image variant unless the user asks to change tracks.
 ---
 
 # Update Dependencies
@@ -18,19 +18,25 @@ Use this skill to make small, consistent dependency bumps in this repository. Tr
    - Edit `docker/sample-build.env` for pinned base-image digests and upstream builder images.
    - Edit `kubernetes/kustomization.yaml` for runtime image tags resolved through Kustomize.
    - Edit `test/hadolint.sh`, `test/license.sh`, or similar test scripts for tooling containers used only in checks.
+   - Edit `.github/workflows/ci.yaml` for GitHub Actions `uses:` pins and workflow-local Java or toolchain versions such as `actions/setup-java` `java-version`.
+   - Edit `console/pom.xml` for Maven dependency, plugin, or tooling versions. Prefer updating a property in `<properties>` when the dependency or plugin already consumes that property.
    - Edit a manifest directly for images not routed through Kustomize, such as `kubernetes/base/tez/ui/deployment.yaml`.
    - Edit a Dockerfile only when the version is declared there, such as `ARG kubectl_version` in `docker/util/Dockerfile`.
 
 3. Choose the target version conservatively.
-   - Prefer the newest available upstream release that stays on the current track or variant.
+   - Prefer the newest available upstream LTS release when the dependency publishes one. If there is no designated LTS line, prefer the newest available upstream release that stays on the current track or variant.
    - Keep distro and runtime qualifiers unless the user asks to change them. Examples: keep `noble`, `24.04`, `jdk21-temurin`, `ubuntu-24.04`, or similar suffixes and prefixes.
    - For digest-pinned images in `docker/sample-build.env`, keep the human-readable tag family shown in the preceding comment and refresh only the digest.
    - For tags that combine multiple dimensions, move only the version component that is clearly intended to float. Example: `tomcat:11.0.18-jdk21-temurin` should usually become a newer Tomcat release that still uses `jdk21-temurin`.
+   - For GitHub Actions refs such as `actions/setup-java@v4`, keep the action family stable and bump only the version suffix unless the user explicitly asks to change the major track or swap actions.
+   - When the current pin is on a non-LTS stream and the upstream project publishes a separate LTS line, prefer moving to the newest released patch on the LTS line instead of the newest non-LTS release. Example: prefer Quarkus `3.33.x` LTS over `3.34.x`.
    - Call out any case where "latest" is ambiguous or would require changing OS family, major runtime, or image flavor.
 
 4. Propagate coupled changes.
    - Keep `test/kubernetes/all.yaml`, `test/kubernetes/ha.yaml`, and `test/kubernetes/llap.yaml` aligned with `kubernetes/kustomization.yaml`; `test/integration.sh` can copy those fixtures over the main kustomization during test runs.
    - When changing a value in `docker/sample-build.env`, verify which `docker/build-*.sh` passes it into which Dockerfile before deciding the bump is complete.
+   - When changing the console Java level in `console/pom.xml`, check `.github/workflows/ci.yaml`, `docker/sample-build.env`, and `docker/build-console.sh` and keep them aligned when the requested bump is a toolchain move.
+   - When `console/pom.xml` exposes a version through `<properties>`, update the property once and keep the plugin or dependency consumers pointed at that property.
    - Preserve quoting and the existing tag-or-digest style unless the user explicitly asks to change it.
 
 5. Validate the bump.
@@ -46,6 +52,8 @@ Use this skill to make small, consistent dependency bumps in this repository. Tr
 - Runtime image tags: `kubernetes/kustomization.yaml`
 - Test kustomization fixtures: `test/kubernetes/*.yaml`
 - Tooling containers used in tests: `test/*.sh`
+- CI workflow pins: `.github/workflows/ci.yaml`
+- Console Maven versions: `console/pom.xml`
 - Direct manifest pins outside Kustomize: `kubernetes/base/**`
 
 ## Search Shortcuts
@@ -54,6 +62,8 @@ Use this skill to make small, consistent dependency bumps in this repository. Tr
 - Run `./.agents/skills/update-dependencies/scripts/find_dependency_refs.sh hadolint` to find a named dependency quickly.
 - Use `rg -n "newTag:" kubernetes/kustomization.yaml test/kubernetes` when aligning runtime tags.
 - Use `rg -n "^[A-Z0-9_]+_IMAGE=" docker/sample-build.env` when auditing base-image digests.
+- Use `rg -n "uses:|java-version:" .github/workflows/ci.yaml` when checking CI workflow pins.
+- Use `rg -n "<[^/][^>]*version>|<maven.compiler.release>" console/pom.xml` when auditing console Maven versions.
 
 ## Guardrails
 
@@ -61,4 +71,6 @@ Use this skill to make small, consistent dependency bumps in this repository. Tr
 - Treat mirrored test fixtures as part of the same change unless the user explicitly wants divergence.
 - Do not edit unrelated component tags just because they appear nearby.
 - Keep the current OS, distro, and runtime track unless the user explicitly asks to move it.
+- Treat an upstream LTS designation as a stronger signal than "latest" when both exist, and call out any dependency where LTS status is unclear or vendor-specific.
+- Do not treat the console module artifact version like `0.5.0-SNAPSHOT` as a dependency pin unless the user explicitly asks for a project version change.
 - Call out when a requested bump likely needs follow-up build or integration testing beyond lint.

--- a/.agents/skills/update-dependencies/references/repo-map.md
+++ b/.agents/skills/update-dependencies/references/repo-map.md
@@ -7,6 +7,8 @@
 | Base build images and digests | `docker/sample-build.env` | `docker/build-*.sh`, `docker/*/Dockerfile` | Contains the Ubuntu, Temurin, Maven, and Keycloak image pins used by the local build scripts. |
 | Runtime Zookage image tags | `kubernetes/kustomization.yaml` | `test/kubernetes/all.yaml`, `test/kubernetes/ha.yaml`, `test/kubernetes/llap.yaml` | `test/integration.sh` can copy a test fixture over the main kustomization before bringing the cluster up. |
 | Lint and check containers | `test/hadolint.sh`, `test/license.sh` | None | Versions live directly in the scripts rather than in a shared config file. |
+| GitHub Actions workflow pins | `.github/workflows/ci.yaml` | None for action-only bumps; `console/pom.xml`, `docker/sample-build.env`, and `docker/build-console.sh` for console Java toolchain moves | Covers `uses:` pins and workflow-local Java/toolchain values such as `actions/setup-java` `java-version`. |
+| Console Maven versions | `console/pom.xml` | `.github/workflows/ci.yaml` for Java level bumps; `docker/console/Dockerfile` consumes the same POM during image builds | Prefer property-backed versions such as `quarkus.platform.version`, plugin versions, and `maven.compiler.release` over repeated consumer edits. Do not treat the project artifact version as a dependency pin by default. |
 | Manifest-local images | `kubernetes/base/**` | None unless the same image is reused elsewhere | Example: `kubernetes/base/tez/ui/deployment.yaml` pins `tomcat:11.0.18-jdk21-temurin` directly. |
 | Dockerfile-local version args | `docker/*/Dockerfile` | Matching `docker/build-*.sh` inputs when applicable | Example: `docker/util/Dockerfile` defines `kubectl_version=v1.35.1`. |
 
@@ -17,13 +19,18 @@
 - `rg -n "newTag:" kubernetes/kustomization.yaml test/kubernetes`
 - `rg -n "ARG .*version|^FROM " docker/*/Dockerfile`
 - `rg -n "^[A-Z0-9_]+_IMAGE=" docker/sample-build.env`
+- `rg -n "uses:|java-version:" .github/workflows/ci.yaml`
+- `rg -n "<[^/][^>]*version>|<maven.compiler.release>" console/pom.xml`
 
 ## Version selection policy
 
-- Treat `latest` as "latest release on the current track", not "switch to a different distro or runtime family".
+- Treat `latest` as "latest patch on the upstream LTS line" when the dependency publishes an LTS stream. If there is no designated LTS line, fall back to the latest release on the current track rather than switching distro or runtime family.
 - Preserve qualifiers such as `noble`, `24.04`, `jdk21`, `temurin`, and `ubuntu-24.04` unless the user asks to change them.
 - For digest pins in `docker/sample-build.env`, use the comment above each variable to identify the tag family that should stay stable while the digest moves forward.
 - For mixed tags like `tomcat:11.0.18-jdk21-temurin`, update the application version while keeping the runtime suffix stable.
+- For GitHub Actions refs like `actions/setup-java@v4`, preserve the owner and action name and only bump the version suffix unless the user asks to change tracks.
+- For `console/pom.xml`, prefer updating a `<properties>` entry once instead of editing every plugin or dependency consumer, and ignore the module artifact version unless the request is explicitly about project versioning.
+- When an upstream project has both LTS and non-LTS lines, prefer the newest released patch on the LTS line even if a newer non-LTS line exists. Example: use Quarkus `3.33.x` LTS instead of `3.34.x`.
 
 ## Current direct pins worth checking first
 
@@ -31,3 +38,5 @@
 - `apache/skywalking-eyes:0.8.0` in `test/license.sh`
 - `tomcat:11.0.18-jdk21-temurin` in `kubernetes/base/tez/ui/deployment.yaml`
 - `kubectl_version=v1.35.2` in `docker/util/Dockerfile`
+- `actions/setup-java@v4` and `java-version: '25'` in `.github/workflows/ci.yaml`
+- `quarkus.platform.version`, `maven.compiler.release`, and plugin version properties in `console/pom.xml`

--- a/.agents/skills/update-dependencies/scripts/find_dependency_refs.sh
+++ b/.agents/skills/update-dependencies/scripts/find_dependency_refs.sh
@@ -16,7 +16,7 @@ set -eu
 usage() {
   echo "Usage: $0 [pattern]" >&2
   echo "Without a pattern, print the common dependency pin locations in this repository." >&2
-  echo "With a pattern, search Docker, Kubernetes, and test files for matching refs." >&2
+  echo "With a pattern, search Docker, Kubernetes, test, CI, and console Maven files for matching refs." >&2
 }
 
 if [ "$#" -gt 1 ]; then
@@ -33,11 +33,11 @@ if [ "$#" -eq 1 ]; then
   readonly matches_file=$(mktemp)
   trap 'rm -f "${matches_file}"' EXIT
 
-  if ! rg -n "$1" docker kubernetes test > "${matches_file}"; then
+  if ! rg -n "$1" docker kubernetes test .github/workflows/ci.yaml console/pom.xml > "${matches_file}"; then
     exit 1
   fi
 
-  readonly likely_pin_pattern='docker run|image:|newTag:|newName:|_IMAGE=|ARG .*version|FROM |--build-arg|uses:'
+  readonly likely_pin_pattern='docker run|image:|newTag:|newName:|_IMAGE=|ARG .*version|FROM |--build-arg|uses:|java-version:|<[A-Za-z0-9_.-]+version>|<maven.compiler.release>'
   if grep -Eq "${likely_pin_pattern}" "${matches_file}"; then
     echo "Likely version pins"
     grep -E "${likely_pin_pattern}" "${matches_file}"
@@ -68,3 +68,11 @@ echo
 
 echo "Direct tool and manifest image pins"
 rg -n "hadolint/hadolint|skywalking-eyes|tomcat:" test kubernetes/base || true
+echo
+
+echo "GitHub Actions workflow pins"
+rg -n "uses:|java-version:" .github/workflows/ci.yaml || true
+echo
+
+echo "Console Maven versions"
+rg -n "<[A-Za-z0-9_.-]+version>|<maven.compiler.release>" console/pom.xml || true

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -29,7 +29,7 @@ limitations under the License.
     <maven.compiler.release>25</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus.platform.version>3.32.3</quarkus.platform.version>
+    <quarkus.platform.version>3.33.1</quarkus.platform.version>
     <spotless-maven-plugin.version>3.4.0</spotless-maven-plugin.version>
     <google-java-format.version>1.35.0</google-java-format.version>
     <surefire-plugin.version>3.5.5</surefire-plugin.version>


### PR DESCRIPTION
## Summary
- expand the `update-dependencies` skill to cover GitHub Actions pins in `.github/workflows/ci.yaml`
- add support for Maven dependency and tooling versions in `console/pom.xml`
- teach the helper script and repo map to discover CI and console version refs
- document LTS-first version selection and update Quarkus to `3.33.1`

## Testing
- `./test/lint.sh`
- Not run (not requested)