### PR TITLE
Add Claude Code configuration and update agent docs

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,17 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if echo \"$TOOL_INPUT\" | grep -q 'git commit'; then \"$CLAUDE_PROJECT_DIR\"/test/lint.sh; fi",
+            "timeout": 120,
+            "statusMessage": "Running lint checks..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,22 @@
 {
+  "permissions": {
+    "allow": [
+      "Bash(./bin/down)",
+      "Bash(./bin/kubectl *)",
+      "Bash(./bin/logs *)",
+      "Bash(./bin/ssh *)",
+      "Bash(./bin/up)",
+      "Bash(./test/hadolint.sh)",
+      "Bash(./test/integration.sh *)",
+      "Bash(./test/integration/*)",
+      "Bash(./test/license.sh)",
+      "Bash(./test/licensefix.sh)",
+      "Bash(./test/lint.sh)",
+      "Bash(./test/shellcheck.sh)",
+      "Bash(./test/yamllint.sh)",
+      "Bash(mvn -f console/pom.xml *)"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -27,6 +27,7 @@ header:
       See the License for the specific language governing permissions and
       limitations under the License.
   paths-ignore:
+  - ".claude/skills"
   - ".git"
   - ".idea"
   - "config"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Changes

- **Add Claude Code settings** (`.claude/settings.json`): Configure pre-tool hooks to run lint checks before git commits
- **Add skills symlink** (`.claude/skills`): Link to shared agents skills directory
- **Update AGENTS.md**: 
  - Clarify `ssh` command defaults to `client-node-0`
  - Add documentation for running individual integration checks and one-off commands
- **Add CLAUDE.md**: Reference documentation for Claude Code context