### PR TITLE
Clarify AGENTS workflow guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,6 @@ This document defines how AI coding agents should be used safely and consistentl
 - Focused lint checks (same tools as `./test/lint.sh`): `./test/hadolint.sh`, `./test/shellcheck.sh`, `./test/yamllint.sh`, `./test/license.sh`
 - To auto-fix license headers: `./test/licensefix.sh`
 - Integration test suite on the current Kubernetes profile: `./test/integration.sh`
-- To switch Kubernetes profile and run the integration suite: `./test/integration.sh [all|auth|ha|llap]`
-- To run an individual integration check directly: `./test/integration/<name>.sh` (for example, `./test/integration/web.sh`)
+- To switch Kubernetes profile and run the integration suite: `./test/integration.sh [all|auth|ha|llap]` (copies `test/kubernetes/<name>.yaml` to `kubernetes/kustomization.yaml` and restarts the cluster)
+- To run an individual integration check directly: `./test/integration/<name>.sh` (for example, `./test/integration/web.sh`, `./test/integration/spark_sql.sh`, or `./test/integration/container_warn.sh`)
 - To execute a one-off command in `client-node-0` during integration/debugging: `./test/integration/run.sh <args...>`


### PR DESCRIPTION
## Summary
- Document the profile-switch behavior of `./test/integration.sh` so the restart side effect is explicit.
- Expand the direct integration examples to cover component and log-check scripts already in the repo.

## Testing
- Not run (not requested)