### PR TITLE
Document console module test command in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,7 @@ This document defines how AI coding agents should be used safely and consistentl
 ## Guidance for Developers
 - Primary quality gate: `./test/lint.sh`
 - Focused lint checks (same tools as `./test/lint.sh`): `./test/hadolint.sh`, `./test/shellcheck.sh`, `./test/yamllint.sh`, `./test/license.sh`
+- To run the console module formatting checks and tests: `mvn -f console/pom.xml test`
 - To auto-fix license headers: `./test/licensefix.sh`
 - Integration test suite on the current Kubernetes profile: `./test/integration.sh`
 - To switch Kubernetes profile and run the integration suite: `./test/integration.sh [all|auth|ha|llap]`


### PR DESCRIPTION
## Summary
- Add the `mvn -f console/pom.xml test` command to the developer guidance in `AGENTS.md`
- Clarify how to run the console module formatting checks and tests

## Testing
- Not run (not requested)