### PR TITLE
Allow writable source mounts in Kubernetes workloads

### DIFF
--- a/kubernetes/base/client/node/statefulset.yaml
+++ b/kubernetes/base/client/node/statefulset.yaml
@@ -72,35 +72,27 @@ spec:
           mountPath: /etc/zookeeper/conf
         - name: hadoop-src
           mountPath: /opt/hadoop
-          readOnly: true
           subPath: opt/hadoop
         - name: hbase-src
           mountPath: /opt/hbase
-          readOnly: true
           subPath: opt/hbase-client
         - name: hive-src
           mountPath: /opt/hive
-          readOnly: true
           subPath: opt/hive
         - name: ozone-src
           mountPath: /opt/ozone
-          readOnly: true
           subPath: opt/ozone
         - name: spark-src
           mountPath: /opt/spark
-          readOnly: true
           subPath: opt/spark
         - name: tez-src
           mountPath: /opt/tez
-          readOnly: true
           subPath: opt/tez
         - name: trino-src
           mountPath: /opt/trino
-          readOnly: true
           subPath: opt/trino
         - name: zookeeper-src
           mountPath: /opt/zookeeper
-          readOnly: true
           subPath: opt/zookeeper
         workingDir: /home/zookage
       terminationGracePeriodSeconds: 0

--- a/kubernetes/base/hbase/master/statefulset.yaml
+++ b/kubernetes/base/hbase/master/statefulset.yaml
@@ -61,7 +61,6 @@ spec:
           mountPath: /mnt
         - name: hadoop-src
           mountPath: /opt/hadoop
-          readOnly: true
           subPath: opt/hadoop
       terminationGracePeriodSeconds: 5
       volumes:

--- a/kubernetes/base/hbase/regionserver/statefulset.yaml
+++ b/kubernetes/base/hbase/regionserver/statefulset.yaml
@@ -56,7 +56,6 @@ spec:
           mountPath: /mnt
         - name: hadoop-src
           mountPath: /opt/hadoop
-          readOnly: true
           subPath: opt/hadoop
       terminationGracePeriodSeconds: 5
       volumes:

--- a/kubernetes/base/hdfs/mkdir/job.yaml
+++ b/kubernetes/base/hdfs/mkdir/job.yaml
@@ -56,7 +56,6 @@ spec:
           mountPath: /etc/hadoop/conf
         - name: hadoop-src
           mountPath: /opt/hadoop
-          readOnly: true
           subPath: opt/hadoop
       restartPolicy: Never
       volumes:

--- a/kubernetes/base/hive-metastore/server/statefulset.yaml
+++ b/kubernetes/base/hive-metastore/server/statefulset.yaml
@@ -66,7 +66,6 @@ spec:
           mountPath: /mnt
         - name: hadoop-src
           mountPath: /opt/hadoop
-          readOnly: true
           subPath: opt/hadoop
       containers:
       - name: metastore
@@ -94,7 +93,6 @@ spec:
           mountPath: /mnt
         - name: hadoop-src
           mountPath: /opt/hadoop
-          readOnly: true
           subPath: opt/hadoop
       terminationGracePeriodSeconds: 5
       volumes:

--- a/kubernetes/base/hive/hiveserver2/deployment.yaml
+++ b/kubernetes/base/hive/hiveserver2/deployment.yaml
@@ -57,11 +57,9 @@ spec:
           mountPath: /etc/tez/conf
         - name: hadoop-src
           mountPath: /opt/hadoop
-          readOnly: true
           subPath: opt/hadoop
         - name: tez-src
           mountPath: /opt/tez
-          readOnly: true
           subPath: opt/tez
       terminationGracePeriodSeconds: 5
       volumes:

--- a/kubernetes/base/hive/llap/statefulset.yaml
+++ b/kubernetes/base/hive/llap/statefulset.yaml
@@ -100,11 +100,9 @@ spec:
           mountPath: /mnt
         - name: hadoop-src
           mountPath: /opt/hadoop
-          readOnly: true
           subPath: opt/hadoop
         - name: tez-src
           mountPath: /opt/tez
-          readOnly: true
           subPath: opt/tez
       terminationGracePeriodSeconds: 5
       volumes:

--- a/kubernetes/base/spark/historyserver/statefulset.yaml
+++ b/kubernetes/base/spark/historyserver/statefulset.yaml
@@ -53,7 +53,6 @@ spec:
           mountPath: /mnt
         - name: hadoop-src
           mountPath: /opt/hadoop
-          readOnly: true
           subPath: opt/hadoop
       terminationGracePeriodSeconds: 5
       volumes:

--- a/kubernetes/base/tez/deploy/job.yaml
+++ b/kubernetes/base/tez/deploy/job.yaml
@@ -49,7 +49,6 @@ spec:
           mountPath: /etc/hadoop/conf
         - name: tez-src
           mountPath: /opt/tez
-          readOnly: true
           subPath: opt/tez
       restartPolicy: Never
       volumes:

--- a/kubernetes/base/tez/ui/deployment.yaml
+++ b/kubernetes/base/tez/ui/deployment.yaml
@@ -36,7 +36,6 @@ spec:
         volumeMounts:
         - name: tez-src
           mountPath: /opt/tez
-          readOnly: true
           subPath: opt/tez
       volumes:
       - name: tez-src

--- a/kubernetes/base/yarn/nodemanager/statefulset.yaml
+++ b/kubernetes/base/yarn/nodemanager/statefulset.yaml
@@ -56,7 +56,6 @@ spec:
           mountPath: /mnt
         - name: tez-src
           mountPath: /opt/tez
-          readOnly: true
           subPath: opt/tez
       terminationGracePeriodSeconds: 5
       volumes:

--- a/kubernetes/patches/authz/hbase.yaml
+++ b/kubernetes/patches/authz/hbase.yaml
@@ -38,7 +38,6 @@ spec:
         volumeMounts:
         - name: ranger-src
           mountPath: /opt/ranger
-          readOnly: true
           subPath: opt/ranger
       volumes:
       - name: ranger-src
@@ -67,7 +66,6 @@ spec:
         volumeMounts:
         - name: ranger-src
           mountPath: /opt/ranger
-          readOnly: true
           subPath: opt/ranger
       volumes:
       - name: ranger-src

--- a/kubernetes/patches/authz/hdfs.yaml
+++ b/kubernetes/patches/authz/hdfs.yaml
@@ -40,7 +40,6 @@ spec:
         volumeMounts:
         - name: ranger-src
           mountPath: /opt/ranger
-          readOnly: true
           subPath: opt/ranger
       volumes:
       - name: ranger-src

--- a/kubernetes/patches/authz/hive-metastore.yaml
+++ b/kubernetes/patches/authz/hive-metastore.yaml
@@ -34,7 +34,6 @@ spec:
         volumeMounts:
         - name: ranger-src
           mountPath: /opt/ranger
-          readOnly: true
           subPath: opt/ranger
       volumes:
       - name: ranger-src

--- a/kubernetes/patches/authz/hive.yaml
+++ b/kubernetes/patches/authz/hive.yaml
@@ -34,7 +34,6 @@ spec:
           mountPath: /mnt
         - name: ranger-src
           mountPath: /opt/ranger
-          readOnly: true
           subPath: opt/ranger
       volumes:
       - name: mnt

--- a/kubernetes/patches/authz/ozone.yaml
+++ b/kubernetes/patches/authz/ozone.yaml
@@ -38,7 +38,6 @@ spec:
         volumeMounts:
         - name: ranger-src
           mountPath: /opt/ranger
-          readOnly: true
           subPath: opt/ranger
       volumes:
       - name: ranger-src

--- a/kubernetes/patches/authz/yarn.yaml
+++ b/kubernetes/patches/authz/yarn.yaml
@@ -39,7 +39,6 @@ spec:
         volumeMounts:
         - name: ranger-src
           mountPath: /opt/ranger
-          readOnly: true
           subPath: opt/ranger
       volumes:
       - name: ranger-src


### PR DESCRIPTION
## Summary
- Remove `readOnly: true` from source-code volume mounts across client, HBase, Hive, Spark, Tez, Yarn, and authz manifests.
- Keep the existing mount paths and `subPath` layout unchanged while allowing containers to write to mounted source trees when needed.

## Testing
- Not run (not requested)