### PR TITLE
Use secrets for Trino catalog credentials

### DIFF
--- a/kubernetes/base/common/config/trino/catalog/hive.properties
+++ b/kubernetes/base/common/config/trino/catalog/hive.properties
@@ -18,8 +18,8 @@ hive.non-managed-table-writes-enabled=true
 hive.temporary-staging-directory-path=/tmp/trino/trino/staging
 
 fs.native-s3.enabled=true
-s3.aws-access-key=zookage
-s3.aws-secret-key=dummy
+s3.aws-access-key=${ENV:AWS_ACCESS_KEY_ID}
+s3.aws-secret-key=${ENV:AWS_SECRET_ACCESS_KEY}
 s3.endpoint=http://ozone-s3g:9878
 s3.region=default
 s3.path-style-access=true

--- a/kubernetes/base/common/config/trino/catalog/iceberg.properties
+++ b/kubernetes/base/common/config/trino/catalog/iceberg.properties
@@ -19,8 +19,8 @@ fs.hadoop.enabled=true
 hive.config.resources=/etc/hadoop/conf/core-site.xml,/etc/hadoop/conf/hdfs-site.xml
 
 fs.native-s3.enabled=true
-s3.aws-access-key=zookage
-s3.aws-secret-key=dummy
+s3.aws-access-key=${ENV:AWS_ACCESS_KEY_ID}
+s3.aws-secret-key=${ENV:AWS_SECRET_ACCESS_KEY}
 s3.endpoint=http://ozone-s3g:9878
 s3.region=default
 s3.path-style-access=true

--- a/kubernetes/base/common/secret/kustomization.yaml
+++ b/kubernetes/base/common/secret/kustomization.yaml
@@ -21,6 +21,10 @@ secretGenerator:
   - AWS_ACCESS_KEY_ID=zookage
   - AWS_SECRET_ACCESS_KEY=dummy
   name: aws-secret
+- literals:
+  - TRINO_REST_CATALOG_OAUTH2_CLIENT_ID=trino
+  - TRINO_REST_CATALOG_OAUTH2_CLIENT_SECRET=trino
+  name: trino-secret
 - files:
   - hadoop/hadoop.jceks
   name: hadoop-secret

--- a/kubernetes/base/trino/coordinator/statefulset.yaml
+++ b/kubernetes/base/trino/coordinator/statefulset.yaml
@@ -44,6 +44,10 @@ spec:
             name: hadoop-env
         - configMapRef:
             name: trino-env
+        - secretRef:
+            name: aws-secret
+        - secretRef:
+            name: trino-secret
         env:
         - name: POD_NAME
           valueFrom:

--- a/kubernetes/base/trino/worker/deployment.yaml
+++ b/kubernetes/base/trino/worker/deployment.yaml
@@ -43,6 +43,10 @@ spec:
             name: hadoop-env
         - configMapRef:
             name: trino-env
+        - secretRef:
+            name: aws-secret
+        - secretRef:
+            name: trino-secret
         env:
         - name: POD_NAME
           valueFrom:

--- a/kubernetes/patches/authn/trino.yaml
+++ b/kubernetes/patches/authn/trino.yaml
@@ -22,14 +22,14 @@ data:
     iceberg.rest-catalog.view-endpoints-enabled=false
     iceberg.rest-catalog.security=OAUTH2
     iceberg.rest-catalog.oauth2.server-uri=http://keycloak-server:8080/realms/zookage/protocol/openid-connect/token
-    iceberg.rest-catalog.oauth2.credential=trino:trino
+    iceberg.rest-catalog.oauth2.credential=${ENV:TRINO_REST_CATALOG_OAUTH2_CLIENT_ID}:${ENV:TRINO_REST_CATALOG_OAUTH2_CLIENT_SECRET}
 
     fs.hadoop.enabled=true
     hive.config.resources=/etc/hadoop/conf/core-site.xml,/etc/hadoop/conf/hdfs-site.xml
 
     fs.native-s3.enabled=true
-    s3.aws-access-key=zookage
-    s3.aws-secret-key=dummy
+    s3.aws-access-key=${ENV:AWS_ACCESS_KEY_ID}
+    s3.aws-secret-key=${ENV:AWS_SECRET_ACCESS_KEY}
     s3.endpoint=http://ozone-s3g:9878
     s3.region=default
     s3.path-style-access=true


### PR DESCRIPTION
## Summary
- Read Trino Iceberg and Hive S3 credentials from environment-backed secrets instead of hardcoded values
- Add a `trino-secret` for the REST catalog OAuth client credentials
- Enable the Trino auth/authz and related Kubernetes overlays in the base kustomization

## Testing
- Not run (not requested)