### PR TITLE
Document dependency and integration validation workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,12 @@ This document defines how AI coding agents should be used safely and consistentl
 - To auto-fix license headers: `./test/licensefix.sh`
 - To configure local Docker image builds, copy `docker/sample-build.env` to `docker/build.env` and adjust source directories/image settings.
 - To build a Docker image, run the matching `docker/build-<component>.sh` script (for example, `docker/build-console.sh` or `docker/build-hadoop.sh`).
+- Before dependency bumps, run `./.agents/skills/update-dependencies/scripts/find_dependency_refs.sh [pattern]` to find repo-local pins and mirrored consumers.
 - Integration test suite on the current Kubernetes profile: `./test/integration.sh`
 - To switch Kubernetes profile and run the integration suite: `./test/integration.sh [all|auth|ha|llap]` (copies `test/kubernetes/<name>.yaml` to `kubernetes/kustomization.yaml` and restarts the cluster)
+- For full pre-merge validation across every checked-in Kubernetes profile, use `./.agents/skills/final-validation/scripts/run_all_variants.sh` (`--list`, `--dry-run`, and `--continue-on-failure` are available).
 - To run an individual integration check directly: `./test/integration/<name>.sh` (for example, `./test/integration/web.sh`, `./test/integration/spark_sql.sh`, or `./test/integration/container_warn.sh`)
 - To execute a one-off command in `client-node-0` during integration/debugging: `./test/integration/run.sh <args...>`
+- S3-backed coverage is embedded in the MR, Spark, Spark SQL, Hive on Tez, Ozone, and Trino integration checks through `test/integration/s3.sh`; run the relevant subsystem check rather than treating it as a standalone suite.
+- To inspect or regenerate checked-in JCEKS secrets, use `./test/jceks show <jceks-file>` or `./test/jceks create <jceks-file>`; `create` reads key-value pairs from `<jceks-file>.properties`.
+- After changing Ranger Kerberos principals or passwords in `kubernetes/base/common/config/openldap/bootstrap.ldif`, run `./docker/generate-keytabs.sh` to regenerate `kubernetes/base/common/secret/ranger/ranger.keytab`.


### PR DESCRIPTION
## Summary
- Document dependency reference checks before version bumps
- Add guidance for full Kubernetes profile validation
- Clarify embedded S3 coverage and JCEKS/keytab maintenance workflows

## Testing
- Not run (not requested)