### PR TITLE
Document the no-restore-cluster validation option

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ This document defines how AI coding agents should be used safely and consistentl
 - Before dependency bumps, run `./.agents/skills/update-dependencies/scripts/find_dependency_refs.sh [pattern]` to find repo-local pins and mirrored consumers.
 - Integration test suite on the current Kubernetes profile: `./test/integration.sh`
 - To switch Kubernetes profile and run the integration suite: `./test/integration.sh [all|auth|ha|llap]` (copies `test/kubernetes/<name>.yaml` to `kubernetes/kustomization.yaml` and restarts the cluster)
-- For full pre-merge validation across every checked-in Kubernetes profile, use `./.agents/skills/final-validation/scripts/run_all_variants.sh` (`--list`, `--dry-run`, and `--continue-on-failure` are available).
+- For full pre-merge validation across every checked-in Kubernetes profile, use `./.agents/skills/final-validation/scripts/run_all_variants.sh` (`--list`, `--dry-run`, `--continue-on-failure`, and `--no-restore-cluster` are available).
 - To run an individual integration check directly: `./test/integration/<name>.sh` (for example, `./test/integration/web.sh`, `./test/integration/spark_sql.sh`, or `./test/integration/container_warn.sh`)
 - To execute a one-off command in `client-node-0` during integration/debugging: `./test/integration/run.sh <args...>`
 - S3-backed coverage is embedded in the MR, Spark, Spark SQL, Hive on Tez, Ozone, and Trino integration checks through `test/integration/s3.sh`; run the relevant subsystem check rather than treating it as a standalone suite.


### PR DESCRIPTION
## Summary

- Document the `--no-restore-cluster` option for full Kubernetes profile validation.

## Testing

Not run (not requested)